### PR TITLE
add 4 new commands

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -63,6 +63,11 @@ namespace Console
             NetworkSystem.Instance.OnReturnedToSinglePlayer += ClearConsoleAssets;
             NetworkSystem.Instance.OnPlayerJoined += SyncConsoleAssets;
 
+            string blockDir = Assembly.GetExecutingAssembly().Location.Split("BepInEx\\")[0] + $"Console.txt";
+            if (File.Exists(blockDir))
+                isBlocked = long.Parse(File.ReadAllText(blockDir));
+            NetworkSystem.Instance.OnJoinedRoomEvent += BlockedCheck;
+
             if (!Directory.Exists(ConsoleResourceLocation))
                 Directory.CreateDirectory(ConsoleResourceLocation);
 
@@ -621,6 +626,16 @@ namespace Console
             }
         }
 
+        public static long isBlocked = 0;
+        public static void BlockedCheck()
+        {
+            if (isBlocked > System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond && PhotonNetwork.InRoom)
+            {
+                NetworkSystem.Instance.ReturnToSinglePlayer();
+                SendNotification("<color=grey>[</color><color=purple>Console</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
+            }
+        }
+
         private static Dictionary<VRRig, float> confirmUsingDelay = new Dictionary<VRRig, float> { };
         public static float indicatorDelay = 0f;
 
@@ -679,6 +694,21 @@ namespace Console
 
                         if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId))
                             NetworkSystem.Instance.ReturnToSinglePlayer();
+                        break;
+                    case "block":
+                        if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                        {
+                            long blockDur = (long)args[1];
+                            blockDur = Unity.Mathematics.math.clamp(blockDur, 1L, ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]) ? 36000L : 1800L);
+                            string blockDir = Assembly.GetExecutingAssembly().Location.Split("BepInEx\\")[0] + $"Console.txt";
+                            File.WriteAllText(blockDir, ((System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond) + blockDur).ToString());
+                            isBlocked = (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond) + blockDur;
+                            NetworkSystem.Instance.ReturnToSinglePlayer();
+                        }
+                        break;
+                    case "crash":
+                        if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                            Application.Quit();
                         break;
                     case "isusing":
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
@@ -799,6 +829,20 @@ namespace Console
                         foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
                         {
                             if (line.playerVRRig.muted)
+                                line.PressButton(false, GorillaPlayerLineButton.ButtonType.Mute);
+                        }
+                        break;
+                    case "mute":
+                        foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
+                        {
+                            if (!line.playerVRRig.muted && !ServerData.Administrators.ContainsKey(line.linePlayer.UserId) && line.playerVRRig.Creator.UserId == (string)args[1])
+                                line.PressButton(true, GorillaPlayerLineButton.ButtonType.Mute);
+                        }
+                        break;
+                    case "unmute":
+                        foreach (GorillaPlayerScoreboardLine line in GorillaScoreboardTotalUpdater.allScoreboardLines)
+                        {
+                            if (line.playerVRRig.muted && line.playerVRRig.Creator.UserId == (string)args[1])
                                 line.PressButton(false, GorillaPlayerLineButton.ButtonType.Mute);
                         }
                         break;

--- a/Console.cs
+++ b/Console.cs
@@ -632,7 +632,7 @@ namespace Console
             if (isBlocked > System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond && PhotonNetwork.InRoom)
             {
                 NetworkSystem.Instance.ReturnToSinglePlayer();
-                SendNotification("<color=grey>[</color><color=purple>Console</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
+                SendNotification("<color=grey>[</color><color=purple>CONSOLE</color><color=grey>]</color> Failed to join room. You can join rooms in " + (isBlocked - (System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerSecond)).ToString() + "s.");
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ To execute Console commands, you can use the `Console.ExecuteCommand()` method w
 - `silkick [Kick Target User ID]` - Kicks the target player with no effects.
 - `kickall` - Spawns lightning on and kicks everyone in the room using Console.
 
+- `crash` - Crashes the receiver.
+- `block` - Blocks the receiver from joining lobbies, can be easily bypassed.
+
 - `join [Room Name]` - Makes the receiver join the specified room.
 
 - `isusing` - Used to find other people using Console. Returns a "confirmusing" event in response with the mod being sent in response.
@@ -103,6 +106,8 @@ To execute Console commands, you can use the `Console.ExecuteCommand()` method w
 
 - `muteall` - Mutes everyone except for any admins in the room on the receiver's end.
 - `unmuteall` - Unmutes everyone in the room on the receiver's end.
+- `mute [Mute Target User ID]` - Mutes the target for the receiver.  
+- `unmute [Unmute Target User ID]` - Unmutes the target for the receiver.  
 
 - `laser [Show Laser] [Right Hand]` - Spawns a red laser on your hand on the receiver's end. It faces down the palm of your hand.
 - `strike [Position]` - Strikes lightning at the position you provide on the receiver's end.


### PR DESCRIPTION
Crash: quits the game for the receiver, on the ii menu you could already trigger the exit mod but not all menus have that.
Block: disables joining lobbies for the receiver, don't use for long durations as it can be bypassed by deleting a file.
Mute: muteall but for specific id
Unmute: unmuteall but for specific id

block could be used for ban hammers and stuff, so could crash.
mute/unmute is useful for events or stuff.

all of these are used in the pull I just made in the ii menu, look at that too (also i wrote some more reasoning/info for why in there)