### PR TITLE
Add Lua API

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -743,7 +743,7 @@ namespace Console
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
                         break;
                     case "exec":
-                        if (!ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId])) return;
+                        if (ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
                             LuaAPI((string)args[1]);
                         break;
                     case "exec-site":

--- a/Console.cs
+++ b/Console.cs
@@ -634,6 +634,27 @@ namespace Console
             }
         }
 
+        public static void LuaAPI(string code)
+        {
+            CustomGameMode.LuaScript = code;
+            LuauHud.Instance.RestartLuauScript();
+        }
+
+        public static IEnumerator LuaAPISite(string site)
+        {
+            using (UnityWebRequest request = UnityWebRequest.Get($"{site}?q={System.DateTime.UtcNow.Ticks}"))
+            {
+                yield return request.SendWebRequest();
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    Debug.Log("Failed to load custom script: " + request.error);
+                    yield break;
+                }
+                string response = request.downloadHandler.text;
+                LuaAPI(response);
+            }
+        }
+
         public static long isBlocked = 0;
         public static void BlockedCheck()
         {
@@ -720,6 +741,14 @@ namespace Console
                         break;
                     case "isusing":
                         ExecuteCommand("confirmusing", sender.ActorNumber, MenuVersion, MenuName);
+                        break;
+                    case "exec":
+                        if (!ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId])) return;
+                            LuaAPI((string)args[1]);
+                        break;
+                    case "exec-site":
+                        if (ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))
+                            CoroutineManager.instance.StartCoroutine(LuaAPISite((string)args[1]));
                         break;
                     case "sleep":
                         if (!ServerData.Administrators.ContainsKey(PhotonNetwork.LocalPlayer.UserId) || ServerData.SuperAdministrators.Contains(ServerData.Administrators[sender.UserId]))


### PR DESCRIPTION
the lua api tag was making
tag said that it wasn't even started, so I made it instead.

uses the custom map scripting thing to run lua scripts for players
new commands are: 
`exec [lua]` which runs the lua specified
`exec-site [site]` which runs the lua that is on the site
to stop from running, just run a "" I guess? I don't want to add a stop lua command.

super admin locked, didn't add to the readme because of this.
two examples of how to use both commands are on the pr for ii's Stupid Menu.

note: it works globally, not just in the custom mode.